### PR TITLE
Re-enabled Self, Party, Player, Raid Player Links, Popup now closed upon selection

### DIFF
--- a/CharacterLinks/CharacterLinks.lua
+++ b/CharacterLinks/CharacterLinks.lua
@@ -8,10 +8,10 @@ UnitPopupButtons["MHP"] = {text = "Mythic Plus Helper", dist = 0, checkable = ni
 UnitPopupButtons["RIO"] = {text = "Raider.IO", dist = 0, checkable = nil}
 UnitPopupButtons["WL"] = {text = "Warcraft Logs", dist = 0, checkable = nil}
 UnitPopupButtons["WP"] = {text = "WoWProgress", dist = 0, checkable = nil}
---table.insert(UnitPopupMenus["SELF"], #(UnitPopupMenus["SELF"])-1, "CL")
---table.insert(UnitPopupMenus["PARTY"], #(UnitPopupMenus["PARTY"])-1, "CL")
---table.insert(UnitPopupMenus["PLAYER"], #(UnitPopupMenus["PLAYER"])-1, "CL")
---table.insert(UnitPopupMenus["RAID_PLAYER"], #(UnitPopupMenus["RAID_PLAYER"])-1, "CL")
+table.insert(UnitPopupMenus["SELF"], #(UnitPopupMenus["SELF"])-1, "CL")
+table.insert(UnitPopupMenus["PARTY"], #(UnitPopupMenus["PARTY"])-1, "CL")
+table.insert(UnitPopupMenus["PLAYER"], #(UnitPopupMenus["PLAYER"])-1, "CL")
+table.insert(UnitPopupMenus["RAID_PLAYER"], #(UnitPopupMenus["RAID_PLAYER"])-1, "CL")
 table.insert(UnitPopupMenus["GUILD"], #(UnitPopupMenus["GUILD"])-1, "CL")
 table.insert(UnitPopupMenus["GUILD_OFFLINE"], #(UnitPopupMenus["GUILD_OFFLINE"])-1, "CL")
 table.insert(UnitPopupMenus["FRIEND"], #(UnitPopupMenus["FRIEND"])-1, "CL")
@@ -128,6 +128,7 @@ hooksecurefunc("UnitPopup_OnClick", function(self)
     else
       ShowUrl(name,site)
     end
+    CloseDropdownMenus();
   end)
 
 -- LFG tool menu when searching for a group


### PR DESCRIPTION
These were my personal edits, noticed Self, Party, Player, and Raid Player were disabled. Not sure if it was intentional or not.

The UnitPopup will now close when a link is selected, makes it much more cleaner, and draws attention to the chatbox.

Visual representation https://i.imgur.com/4hIdvOA.gifv